### PR TITLE
Move optional viewset keys to serializer

### DIFF
--- a/drf_react_template/mixins.py
+++ b/drf_react_template/mixins.py
@@ -4,24 +4,16 @@ from rest_framework.mixins import Response
 from rest_framework.viewsets import GenericViewSet
 
 from drf_react_template.renderers import JSONSerializerRenderer
-from drf_react_template.schema_form_encoder import ColumnProcessor
 
 
 class FormSchemaViewSetMixin(GenericViewSet):
     renderer_classes = (JSONSerializerRenderer,)
     serializer_list_class = None
 
-    list_sort = {}
-
     def get_serializer_class(self):
         if self.action == 'list' and self.serializer_list_class:
             return self.serializer_list_class
         return self.serializer_class
-
-    def get_renderer_context(self):
-        context = super().get_renderer_context()
-        context[ColumnProcessor.LIST_FIELDS_SORT_KEY] = self.list_sort
-        return context
 
     def finalize_response(self, request, response, *args, **kwargs):
         response = super(FormSchemaViewSetMixin, self).finalize_response(

--- a/drf_react_template/mixins.py
+++ b/drf_react_template/mixins.py
@@ -13,13 +13,10 @@ class FormSchemaViewSetMixin(GenericViewSet):
     list_fields = []
     list_sort = {}
 
-    type_map_overrides = {}
-
     def get_renderer_context(self):
         context = super().get_renderer_context()
         context[ColumnProcessor.LIST_FIELDS_KEY] = self.list_fields
         context[ColumnProcessor.LIST_FIELDS_SORT_KEY] = self.list_sort
-        context[ProcessingMixin.TYPE_MAP_OVERRIDES_KEY] = self.type_map_overrides
         return context
 
     def finalize_response(self, request, response, *args, **kwargs):

--- a/drf_react_template/mixins.py
+++ b/drf_react_template/mixins.py
@@ -14,7 +14,7 @@ class FormSchemaViewSetMixin(GenericViewSet):
     list_sort = {}
 
     def get_serializer_class(self):
-        if self.action == 'list':
+        if self.action == 'list' and self.serializer_list_class:
             return self.serializer_list_class
         return self.serializer_class
 

--- a/drf_react_template/mixins.py
+++ b/drf_react_template/mixins.py
@@ -4,18 +4,22 @@ from rest_framework.mixins import Response
 from rest_framework.viewsets import GenericViewSet
 
 from drf_react_template.renderers import JSONSerializerRenderer
-from drf_react_template.schema_form_encoder import ColumnProcessor, ProcessingMixin
+from drf_react_template.schema_form_encoder import ColumnProcessor
 
 
 class FormSchemaViewSetMixin(GenericViewSet):
     renderer_classes = (JSONSerializerRenderer,)
+    serializer_list_class = None
 
-    list_fields = []
     list_sort = {}
+
+    def get_serializer_class(self):
+        if self.action == 'list':
+            return self.serializer_list_class
+        return self.serializer_class
 
     def get_renderer_context(self):
         context = super().get_renderer_context()
-        context[ColumnProcessor.LIST_FIELDS_KEY] = self.list_fields
         context[ColumnProcessor.LIST_FIELDS_SORT_KEY] = self.list_sort
         return context
 

--- a/drf_react_template/schema_form_encoder.py
+++ b/drf_react_template/schema_form_encoder.py
@@ -230,20 +230,6 @@ class UiSchemaProcessor(ProcessingMixin):
 
 
 class ColumnProcessor(ProcessingMixin):
-    LIST_FIELDS_KEY: str = 'list_fields'
-    LIST_FIELDS_SORT_KEY: str = 'list_fields_sort'
-
-    def __init__(
-        self,
-        serializer: SerializerType,
-        renderer_context: Dict[str, Any],
-        prefix: str = '',
-    ):
-        super(ColumnProcessor, self).__init__(serializer, renderer_context, prefix)
-        self.list_sort: Dict[str, str] = self.renderer_context.get(
-            self.LIST_FIELDS_SORT_KEY, {}
-        )
-
     def _get_column_properties(
         self, field: SerializerType, name: str
     ) -> Dict[str, str]:
@@ -253,8 +239,12 @@ class ColumnProcessor(ProcessingMixin):
             'dataIndex': data_index,
             'key': name,
         }
-        sort_order = self.list_sort.get(data_index)
+        sort_order = field.style.get('schema:sort')
         if sort_order:
+            if sort_order not in ['ascend', 'descend']:
+                raise ValueError(
+                    f"The {data_index} field 'style['schema:sort']' value must be either 'ascend' or 'descend'"
+                )
             result['defaultSortOrder'] = sort_order
         return result
 

--- a/drf_react_template/schema_form_encoder.py
+++ b/drf_react_template/schema_form_encoder.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from django.core.serializers.json import DjangoJSONEncoder
 from rest_framework import fields, serializers
@@ -240,30 +240,9 @@ class ColumnProcessor(ProcessingMixin):
         prefix: str = '',
     ):
         super(ColumnProcessor, self).__init__(serializer, renderer_context, prefix)
-        self.list_fields: List[str] = self.renderer_context.get(
-            self.LIST_FIELDS_KEY, []
-        )
         self.list_sort: Dict[str, str] = self.renderer_context.get(
             self.LIST_FIELDS_SORT_KEY, {}
         )
-        self._validate_list_params()
-
-    def _validate_list_params(self):
-        if self.list_fields:
-            if any(not isinstance(name, str) for name in self.list_fields):
-                raise TypeError('The list_fields must be a list of strings, or empty')
-        if self.list_sort:
-            if self.list_fields and any(
-                name not in self.list_fields for name in self.list_sort.keys()
-            ):
-                raise KeyError(
-                    'The list_sort must be a dict where all the keys '
-                    'are in list_fields (if it is used)'
-                )
-            if any(val not in ['ascend', 'descend'] for val in self.list_sort.values()):
-                raise ValueError(
-                    'Every value in list_sort should be either "ascend" or "descend"'
-                )
 
     def _get_column_properties(
         self, field: SerializerType, name: str
@@ -293,8 +272,6 @@ class ColumnProcessor(ProcessingMixin):
                     ).get_schema()
                 )
             else:
-                if self.list_fields and data_index not in self.list_fields:
-                    continue
                 result.append(self._get_column_properties(field, name))
         return result
 

--- a/drf_react_template/schema_form_encoder.py
+++ b/drf_react_template/schema_form_encoder.py
@@ -202,7 +202,10 @@ class UiSchemaProcessor(ProcessingMixin):
             result['ui:widget'] = widget
         if help_text:
             result['ui:help'] = help_text
-        result.update(field.style or {})
+        style_dict = {
+            k: v for k, v in (field.style or {}).items() if not k.startswith("schema:")
+        }
+        result.update(style_dict)
         return result
 
     def _get_all_ui_properties(self) -> Dict[str, Any]:

--- a/drf_react_template/schema_form_encoder.py
+++ b/drf_react_template/schema_form_encoder.py
@@ -44,6 +44,7 @@ class ProcessingMixin:
     def _get_type_map_value(self, field: SerializerType):
         result = {
             'type': field.style.get('schema:type'),
+            'enum': field.style.get('schema:enum'),
             'widget': field.style.get('ui:widget'),
         }
         result_default = self.TYPE_MAP.get(type(field).__name__, {})

--- a/example/polls/serializers.py
+++ b/example/polls/serializers.py
@@ -10,7 +10,7 @@ class QuestionListSerializer(serializers.Serializer):
 
 
 class ChoiceSerializer(serializers.Serializer):
-    choice_text = serializers.CharField()
+    choice_text = serializers.CharField(style={'ui:widget': 'textarea'})
     votes = serializers.IntegerField(default=0)
 
     class Meta:
@@ -18,8 +18,10 @@ class ChoiceSerializer(serializers.Serializer):
 
 
 class QuestionSerializer(serializers.Serializer):
-    question_text = serializers.CharField()
-    pub_date = serializers.DateField(label='date published')
+    question_text = serializers.CharField(style={'ui:widget': 'textarea'})
+    pub_date = serializers.DateField(
+        label='date published', style={'ui:widget': 'DatePickerWidget'}
+    )
     choices = ChoiceSerializer(many=True)
 
     class Meta:

--- a/example/polls/viewsets.py
+++ b/example/polls/viewsets.py
@@ -11,11 +11,8 @@ class PollViewSet(
     FormSchemaViewSetMixin,
 ):
     queryset = models.Question.objects.all().prefetch_related('choice_set')
-
-    def get_serializer_class(self):
-        if self.action == 'list':
-            return serializers.QuestionListSerializer
-        return serializers.QuestionSerializer
+    serializer_class = serializers.QuestionSerializer
+    serializer_list_class = serializers.QuestionListSerializer
 
     def get_object(self):
         return get_object_or_404(

--- a/example/polls/viewsets.py
+++ b/example/polls/viewsets.py
@@ -12,12 +12,6 @@ class PollViewSet(
 ):
     queryset = models.Question.objects.all().prefetch_related('choice_set')
 
-    type_map_overrides = {
-        'pub_date': {'type': 'string', 'widget': 'DatePickerWidget'},
-        'question_text': {'type': 'string', 'widget': 'textarea'},
-        'choices.choice_text': {'type': 'string', 'widget': 'textarea'},
-    }
-
     def get_serializer_class(self):
         if self.action == 'list':
             return serializers.QuestionListSerializer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,17 +21,6 @@ def polls_create_url(polls_list_url):
 
 
 @pytest.fixture
-def question_and_choice_context():
-    return {
-        ColumnProcessor.TYPE_MAP_OVERRIDES_KEY: {
-            'pub_date': {'type': 'string', 'widget': 'DatePickerWidget'},
-            'question_text': {'type': 'string', 'widget': 'textarea'},
-            'choices.choice_text': {'type': 'string', 'widget': 'textarea'},
-        }
-    }
-
-
-@pytest.fixture
 def question_and_choice_retrieve_expected_schema():
     return {
         'title': 'Question',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,16 @@ def polls_create_url(polls_list_url):
 
 
 @pytest.fixture
+def question():
+    return factories.QuestionFactory(choice=choice)
+
+
+@pytest.fixture
+def choice(question):
+    return factories.ChoiceFactory(question=question)
+
+
+@pytest.fixture
 def question_and_choice_retrieve_expected_schema():
     return {
         'title': 'Question',
@@ -72,13 +82,3 @@ def question_and_choice_list_expected_schema():
         },
         {'title': 'date published', 'dataIndex': 'pub_date', 'key': 'pub_date'},
     ]
-
-
-@pytest.fixture
-def question():
-    return factories.QuestionFactory(choice=choice)
-
-
-@pytest.fixture
-def choice(question):
-    return factories.ChoiceFactory(question=question)

--- a/tests/test_schema_form_encoder.py
+++ b/tests/test_schema_form_encoder.py
@@ -1,3 +1,4 @@
+import pytest
 from rest_framework import serializers
 
 from drf_react_template.schema_form_encoder import (
@@ -45,3 +46,23 @@ def test_choice_custom_widget_and_type():
 
     result = UiSchemaProcessor(CustomWidgetSerializer(), {}).get_ui_schema()
     assert result['choice_text']['ui:widget'] == new_widget
+
+
+def test_question_list_sort():
+    order = 'ascend'
+
+    class QuestionListSortSerializer(QuestionListSerializer):
+        pub_date = serializers.DateField(style={'schema:sort': order})
+
+    result = ColumnProcessor(QuestionListSortSerializer(), {}).get_schema()
+    assert result[1]['defaultSortOrder'] == order
+
+
+def test_question_list_sort_bad_key():
+    order = 'BAD_KEY'
+
+    class QuestionListSortSerializer(QuestionListSerializer):
+        pub_date = serializers.DateField(style={'schema:sort': order})
+
+    with pytest.raises(ValueError):
+        ColumnProcessor(QuestionListSortSerializer(), {}).get_schema()

--- a/tests/test_schema_form_encoder.py
+++ b/tests/test_schema_form_encoder.py
@@ -1,9 +1,15 @@
+from rest_framework import serializers
+
 from drf_react_template.schema_form_encoder import (
     ColumnProcessor,
     SchemaProcessor,
     UiSchemaProcessor,
 )
-from example.polls.serializers import QuestionListSerializer, QuestionSerializer
+from example.polls.serializers import (
+    ChoiceSerializer,
+    QuestionListSerializer,
+    QuestionSerializer,
+)
 
 
 def test_question_and_choice_retrieve_schema(
@@ -23,3 +29,19 @@ def test_question_and_choice_retrieve_ui_schema(
 def test_question_and_choice_list(question_and_choice_list_expected_schema):
     result = ColumnProcessor(QuestionListSerializer(), {}).get_schema()
     assert result == question_and_choice_list_expected_schema
+
+
+def test_choice_custom_widget_and_type():
+    new_widget = 'CustomWidget'
+    new_type = 'CustomType'
+
+    class CustomWidgetSerializer(ChoiceSerializer):
+        choice_text = serializers.CharField(
+            style={'ui:widget': new_widget, 'schema:type': new_type}
+        )
+
+    result = SchemaProcessor(CustomWidgetSerializer(), {}).get_schema()
+    assert result['properties']['choice_text']['type'] == new_type
+
+    result = UiSchemaProcessor(CustomWidgetSerializer(), {}).get_ui_schema()
+    assert result['choice_text']['ui:widget'] == new_widget

--- a/tests/test_schema_form_encoder.py
+++ b/tests/test_schema_form_encoder.py
@@ -7,22 +7,16 @@ from example.polls.serializers import QuestionListSerializer, QuestionSerializer
 
 
 def test_question_and_choice_retrieve_schema(
-    question_and_choice_context,
     question_and_choice_retrieve_expected_schema,
 ):
-    result = SchemaProcessor(
-        QuestionSerializer(), question_and_choice_context
-    ).get_schema()
+    result = SchemaProcessor(QuestionSerializer(), {}).get_schema()
     assert result == question_and_choice_retrieve_expected_schema
 
 
 def test_question_and_choice_retrieve_ui_schema(
-    question_and_choice_context,
     question_and_choice_retrieve_expected_ui_schema,
 ):
-    result = UiSchemaProcessor(
-        QuestionSerializer(), question_and_choice_context
-    ).get_ui_schema()
+    result = UiSchemaProcessor(QuestionSerializer(), {}).get_ui_schema()
     assert result == question_and_choice_retrieve_expected_ui_schema
 
 


### PR DESCRIPTION
This PR removes the following keys from `FormSchemaViewSetMixin` and replaces them with serializer field equivalents:
- `list_fields`: Replaced with having a seperate serializer for `list` actions. 
- `list_sort`: Replaced with `style={'schema:sort': 'ascend|decend'}`
- `type_map_overrides`: Replaced with: `style={'schema:type': 'string', 'schema:enum': 'choices', 'ui:widget': 'textarea'}`. If any fields are missing the encoder will try and update with its defaults.