### PR TITLE
SMB-447 Override Schema Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,31 @@ additional attributes for custom widgets.
 
 The following are a list of valid (tested) keys and their uses.
 
+###### Field Overrides 
+
+Since this framework doesn't cover 100% of the features of the `react-jsonschema-form`, it is possible to provide 
+`dict` objects which override the individual field properties:
+```python
+
+```
+
 ###### List Sort Order
 Sends the `defaultSortOrder` key with the `list` action serializer:
 ```python
-choice_text = serializers.CharField(, style={'schema:sort': 'ascend'})
+choice_text = serializers.CharField(
+    style={
+        'schema:override': {'type': 'string', 'title': 'Overridden title'},
+        'uiSchema:override': {'ui:widget': 'updown'},
+        'column:override': {
+            'title': 'Overridden title',
+            'dataIndex': 'question_text',
+            'key': 'question_text',
+        }
+    }
+)
 ```
+**Note**: There is no validation around these overrides, so it is left up to the developer to ensure the resulting
+schema is valid.
 
 ###### Widget, Type, and Enum
 While the framework tries to provide sensible defaults for DRF fields, 

--- a/drf_react_template/schema_form_encoder.py
+++ b/drf_react_template/schema_form_encoder.py
@@ -11,6 +11,15 @@ SerializerType = Union[
     serializers.Field,
 ]
 
+SCHEMA_OVERRIDE_KEY = 'schema:override'
+UI_SCHEMA_OVERRIDE_KEY = 'uiSchema:override'
+COLUMN_PROCESSOR_OVERRIDE_KEY = 'column:override'
+STYLE_KEYS_TO_IGNORE = [
+    SCHEMA_OVERRIDE_KEY,
+    UI_SCHEMA_OVERRIDE_KEY,
+    COLUMN_PROCESSOR_OVERRIDE_KEY,
+]
+
 
 class ProcessingMixin:
     TYPE_MAP: Dict[str, Dict[str, str]] = {
@@ -55,6 +64,10 @@ class ProcessingMixin:
 
     def _generate_data_index(self, name: str) -> str:
         return f'{self.prefix}.{name}' if self.prefix else name
+
+    @staticmethod
+    def _get_style_dict(field):
+        return field.style or {}
 
     def _get_title(self, field: SerializerType, name: str) -> str:
         result = field.label
@@ -152,7 +165,8 @@ class SchemaProcessor(ProcessingMixin):
                     field, self.renderer_context, prefix=self._generate_data_index(name)
                 ).get_schema()
             else:
-                result[name] = self._get_field_properties(field, name)
+                override = self._get_style_dict(field).get(SCHEMA_OVERRIDE_KEY)
+                result[name] = override or self._get_field_properties(field, name)
         return result
 
     def get_schema(self) -> Dict[str, Any]:
@@ -182,6 +196,13 @@ class UiSchemaProcessor(ProcessingMixin):
             return list(self.serializer.child.Meta.fields)
         return list(self.serializer.Meta.fields)
 
+    def _get_style_dict(self, field) -> Dict[str, Any]:
+        style_dict = {}
+        for k, v in self._get_style_dict(field).items():
+            if not k.startswith("schema:") and k not in STYLE_KEYS_TO_IGNORE:
+                style_dict[k] = v
+        return style_dict
+
     def _get_ui_field_properties(
         self, field: SerializerType, name: str
     ) -> Dict[str, Any]:
@@ -203,16 +224,14 @@ class UiSchemaProcessor(ProcessingMixin):
             result['ui:widget'] = widget
         if help_text:
             result['ui:help'] = help_text
-        style_dict = {
-            k: v for k, v in (field.style or {}).items() if not k.startswith("schema:")
-        }
-        result.update(style_dict)
+        result.update(self._get_style_dict(field))
         return result
 
     def _get_all_ui_properties(self) -> Dict[str, Any]:
         result = {}
         for name, field in self.fields:
-            result[name] = self._get_ui_field_properties(field, name)
+            override = self._get_style_dict(field).get(UI_SCHEMA_OVERRIDE_KEY)
+            result[name] = override or self._get_ui_field_properties(field, name)
         return result
 
     def get_ui_schema(self) -> Dict[str, Any]:
@@ -264,7 +283,10 @@ class ColumnProcessor(ProcessingMixin):
                     ).get_schema()
                 )
             else:
-                result.append(self._get_column_properties(field, name))
+                override = self._get_style_dict(field).get(
+                    COLUMN_PROCESSOR_OVERRIDE_KEY
+                )
+                result.append(override or self._get_column_properties(field, name))
         return result
 
 

--- a/drf_react_template/schema_form_encoder.py
+++ b/drf_react_template/schema_form_encoder.py
@@ -65,10 +65,6 @@ class ProcessingMixin:
     def _generate_data_index(self, name: str) -> str:
         return f'{self.prefix}.{name}' if self.prefix else name
 
-    @staticmethod
-    def _get_style_dict(field):
-        return field.style or {}
-
     def _get_title(self, field: SerializerType, name: str) -> str:
         result = field.label
         if result is None:
@@ -165,7 +161,7 @@ class SchemaProcessor(ProcessingMixin):
                     field, self.renderer_context, prefix=self._generate_data_index(name)
                 ).get_schema()
             else:
-                override = self._get_style_dict(field).get(SCHEMA_OVERRIDE_KEY)
+                override = field.style.get(SCHEMA_OVERRIDE_KEY)
                 result[name] = override or self._get_field_properties(field, name)
         return result
 
@@ -224,13 +220,13 @@ class UiSchemaProcessor(ProcessingMixin):
             result['ui:widget'] = widget
         if help_text:
             result['ui:help'] = help_text
-        result.update(self._get_style_dict(field))
+        result.update(field.style)
         return result
 
     def _get_all_ui_properties(self) -> Dict[str, Any]:
         result = {}
         for name, field in self.fields:
-            override = self._get_style_dict(field).get(UI_SCHEMA_OVERRIDE_KEY)
+            override = field.style.get(UI_SCHEMA_OVERRIDE_KEY)
             result[name] = override or self._get_ui_field_properties(field, name)
         return result
 
@@ -283,9 +279,7 @@ class ColumnProcessor(ProcessingMixin):
                     ).get_schema()
                 )
             else:
-                override = self._get_style_dict(field).get(
-                    COLUMN_PROCESSOR_OVERRIDE_KEY
-                )
+                override = field.style.get(COLUMN_PROCESSOR_OVERRIDE_KEY)
                 result.append(override or self._get_column_properties(field, name))
         return result
 

--- a/tests/test_schema_form_encoder.py
+++ b/tests/test_schema_form_encoder.py
@@ -2,6 +2,9 @@ import pytest
 from rest_framework import serializers
 
 from drf_react_template.schema_form_encoder import (
+    COLUMN_PROCESSOR_OVERRIDE_KEY,
+    SCHEMA_OVERRIDE_KEY,
+    UI_SCHEMA_OVERRIDE_KEY,
     ColumnProcessor,
     SchemaProcessor,
     UiSchemaProcessor,
@@ -193,4 +196,45 @@ def test_question_list_sort_bad_key():
         pub_date = serializers.DateField(style={'schema:sort': order})
 
     with pytest.raises(ValueError):
+
         ColumnProcessor(QuestionListSortSerializer(), {}).get_schema()
+
+
+def test_choice_schema_override():
+    title_override = 'Override'
+
+    class SchemaOverrideSerializer(ChoiceSerializer):
+        choice_text = serializers.CharField(
+            style={SCHEMA_OVERRIDE_KEY: {'type': 'string', 'title': title_override}}
+        )
+
+    result = SchemaProcessor(SchemaOverrideSerializer(), {}).get_schema()
+    assert result['properties']['choice_text']['title'] == title_override
+
+
+def test_choice_ui_schema_override():
+    ui_override = {'ui:widget': 'updown'}
+
+    class UiSchemaOverrideSerializer(ChoiceSerializer):
+        choice_text = serializers.CharField(style={UI_SCHEMA_OVERRIDE_KEY: ui_override})
+
+    result = UiSchemaProcessor(UiSchemaOverrideSerializer(), {}).get_ui_schema()
+    assert result['choice_text'] == ui_override
+
+
+def test_question_and_choice_list_override():
+    title_override = 'Override'
+
+    class ListOverrideSerializer(QuestionListSerializer):
+        question_text = serializers.CharField(
+            style={
+                COLUMN_PROCESSOR_OVERRIDE_KEY: {
+                    'title': title_override,
+                    'dataIndex': 'question_text',
+                    'key': 'question_text',
+                }
+            }
+        )
+
+    result = ColumnProcessor(ListOverrideSerializer(), {}).get_schema()
+    assert result[0]['title'] == title_override


### PR DESCRIPTION
This PR adds additional special keys to the `style` object of individual fields:
```
SCHEMA_OVERRIDE_KEY = 'schema:override'
UI_SCHEMA_OVERRIDE_KEY = 'uiSchema:override'
COLUMN_PROCESSOR_OVERRIDE_KEY = 'column:override'
```
These can be used to replace the individual field `properties` objects to allow for a wider range of features. 