### PR TITLE
SMB-508 Fix Github Actions

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Install Poetry
-      uses: dschep/install-poetry-action@v1.2
+      uses: snok/install-poetry@v1.1.1
     - name: Cache Poetry virtualenv
       uses: actions/cache@v1
       id: cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Install Poetry
-        uses: dschep/install-poetry-action@v1.2
+        uses: snok/install-poetry@v1.1.1
       - name: Cache Poetry virtualenv
         uses: actions/cache@v1
         id: cache


### PR DESCRIPTION
See: https://github.com/yoyowallet/drf-react-template-framework/actions/runs/371882085

Due to a security patch, github has disabled some functionality used by `install-poetry-action` which results in breaking actions (and therefore the inability to merge or release). 

`install-poetry-action` is also no longer maintained and advises the use of https://github.com/snok/install-poetry which should be tested to see if it handles the security issue above