### PR TITLE
Adds length props to char field

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ choice_text = serializers.CharField(default='example text')
 ```
 Note: This has no effect on `list` actions.
 
+##### Min and Max Length
+Optionally validates the text to be shorter than max_length and longer than min_length
+By setting the json-schema property will contain `minLength` and `maxLength` attributes. The rendered html input will contain the maxlength and minlength attributes. 
+```python
+choice_text = serializers.CharField(min_length=3, max_length=100)
+```
+Note: This has no effect on `list` actions.
+
 ##### Style
 The DRF `style` parameter is a `dict` and is therefore used for a number of different parameters.
 There are a [number of options](https://react-jsonschema-form.readthedocs.io/en/latest/api-reference/uiSchema/)

--- a/drf_react_template/schema_form_encoder.py
+++ b/drf_react_template/schema_form_encoder.py
@@ -165,6 +165,11 @@ class SchemaProcessor(ProcessingMixin):
                 result['minItems'] = field.min_length
             result['items'] = self._get_field_properties(field.child, "")
             result['uniqueItems'] = True
+        elif isinstance(field, serializers.CharField):
+            if field.min_length:
+                result['minLength'] = field.min_length
+            if field.max_length:
+                result['maxLength'] = field.max_length
         else:
             if field.allow_null:
                 result['type'] = [result['type'], 'null']

--- a/tests/test_schema_form_encoder.py
+++ b/tests/test_schema_form_encoder.py
@@ -131,6 +131,19 @@ def test_default():
     assert result['properties']['choice_text']['default'] == new_default
     assert 'choice_text' not in result['required']
 
+def test_min_length():
+    class MinLengthSerializer(ChoiceSerializer):
+        choice_text = serializers.CharField(min_length=3)
+
+    result = SchemaProcessor(MinLengthSerializer(), {}).get_schema()
+    assert 'minLength' in result['properties']['choice_text']
+
+def test_max_length():
+    class MaxLengthSerializer(ChoiceSerializer):
+        choice_text = serializers.CharField(max_length=50)
+
+    result = SchemaProcessor(MaxLengthSerializer(), {}).get_schema()
+    assert 'maxLength' in result['properties']['choice_text']
 
 def test_choice_custom_widget_and_type():
     new_widget = 'CustomWidget'


### PR DESCRIPTION
Noticed we weren't transforming the min/max_length properties of the CharField to the corresponding json-schema properties.

Hope this checks out!