### PR TITLE
AttributeError: 'UniqueValidator' object has no attribute 'code'

### DIFF
--- a/drf_react_template/schema_form_encoder.py
+++ b/drf_react_template/schema_form_encoder.py
@@ -144,9 +144,9 @@ class SchemaProcessor(ProcessingMixin):
 
     def _is_serializer_optional(self) -> bool:
         return (
-            self.serializer.allow_empty
-            or (not self.serializer.required)
-            or self.serializer.allow_null
+            self.serializer.allow_empty or
+            (not self.serializer.required) or
+            self.serializer.allow_null
         )
 
     def _get_serializer_title(self) -> str:
@@ -413,7 +413,11 @@ class UiSchemaProcessor(ProcessingMixin):
         ]
         if custom_validators:
             result['ui:custom-validators'] = [
-                {'code': v.code, 'message': v.message} for v in custom_validators
+                {
+                    'code': getattr(v, 'code', v.__class__.__name__.lower()),
+                    'message': getattr(v, 'message')
+                }
+                for v in custom_validators
             ]
 
         return result


### PR DESCRIPTION
Check for code attributes in each custom validator object and default to class name if not set.